### PR TITLE
Forzar EOL = LF en los archivos .sh para evitar problemas en windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
 *.sh text eol=lf


### PR DESCRIPTION
Este pull request aborda un problema crítico en el sistema relacionado con la inicialización del esquema de la base de datos. Anteriormente, el esquema no se ejecutaba correctamente en el primer inicio, lo que causaba problemas en el funcionamiento del sistema. Esto era debido a que Windows reemplaza el sistema de EOF a un tipo LF/CR, provocando un error en el contenedor de Postgis, que ejecuta algunos archivos .sh en su primer inicio.

Cómo reproducir el problema
Clonar el repositorio en Windows e inicializar el contenedor.

Solución:
Se agregó un .gitattributes especificando que los archivos .sh tengan un fin de línea tipo UNIX (LF).
Impacto:
Esta corrección resuelve el problema crítico que impedía que el sistema funcionara correctamente en su estado inicial.
Se inicializa el schema.sql automáticamente.

Pasos de Prueba:
Para verificar que los cambios funcionan, clonar el repositorio y verificar que los archivos .sh ya no tienen el CR, permitiendo inicializar los contenedores con éxito.